### PR TITLE
Drop testing for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.6", "3.7", "3.8"]
+        python_version: ["3.7", "3.8"]
         featuretools_version: ["Release", "Main"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.6", "3.7", "3.8"]
+        python_version: ["3.7", "3.8"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.6", "3.7", "3.8"]
+        python_version: ["3.7", "3.8"]
         featuretools_version: ["Release", "Main"]
     steps:
       - name: Set up python ${{ matrix.python_version }}


### PR DESCRIPTION
Fixes #74. Branch protection rules require updating.