### PR TITLE
Add requirements.txt file to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
+include *.txt
 include LICENSE
 include README.md
-include TSFRESH_LICENSE.txt
-include test-requirements.txt
 include featuretools_tsfresh_primitives/tests/test_primitives.json


### PR DESCRIPTION
Conda-forge recipe was failing [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=399678&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=1060) because we haven't been packaging the requirements file. 